### PR TITLE
chore: bump mockito version to 4.10.0

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -32,7 +32,7 @@ dependencies {
     testImplementation(group = "org.junit.jupiter", name = "junit-jupiter-engine", version = junitVersion)
 
     // mocking and test injection used by runelite client
-    testImplementation(group = "org.mockito", name = "mockito-core", version = "4.9.0") // runelite uses 3.1.0
+    testImplementation(group = "org.mockito", name = "mockito-core", version = "4.10.0") // runelite uses 3.1.0
     testImplementation(group = "com.google.inject.extensions", name = "guice-testlib", version = "4.1.0") {
         exclude(group = "com.google.inject", module = "guice") // already provided by runelite client
     }


### PR DESCRIPTION
https://github.com/mockito/mockito/releases/tag/v4.10.0
