### PR TITLE
fix(metanotifier): Make onVarbit check for isEnabled

### DIFF
--- a/src/main/java/dinkplugin/notifiers/MetaNotifier.java
+++ b/src/main/java/dinkplugin/notifiers/MetaNotifier.java
@@ -83,7 +83,7 @@ public class MetaNotifier extends BaseNotifier {
     }
 
     public void onVarbit(VarbitChanged event) {
-        if (event.getVarbitId() == VarbitID.TOA_VAULT_SARCOPHAGUS && event.getValue() % 2 == 1) {
+        if (event.getVarbitId() == VarbitID.TOA_VAULT_SARCOPHAGUS && event.getValue() % 2 == 1 && isEnabled()) {
             clientThread.invokeAtTickEnd(this::notifyPurpleAmascut);
         }
     }


### PR DESCRIPTION
Add isEnabled check to onVarbit as it was firing without metadata handler being filled out